### PR TITLE
Correcting error variable. error handled should be of http call

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports.init = function(config, logger, stats) {
                             } else {
                                 debug("key not found in cache");
                                     request(lookupEndpoint + "?basePath=" + search, function(error, response, body) {
-                                        if (!err) {
+                                        if (!error) {
                                             var endpoint = JSON.parse(body);
                                             if (endpoint.endpoint) {
                                                 debug("found endpoint " + endpoint.endpoint);
@@ -70,7 +70,7 @@ module.exports.init = function(config, logger, stats) {
                                                 cache.set(search, target);
                                             }
                                         } else {
-                                            debug(err);
+                                            debug(error);
                                             debug("endpoint not found, using proxy endpoint");
                                             cache.set(search, target);
                                         }


### PR DESCRIPTION
In case value is not found in the cache, http call is made to fetch target endpoint from edge. In this case, http error should be handled and I have made changes for same. Please review the pull request. Thanks.